### PR TITLE
Update version of official schema

### DIFF
--- a/lc-gml/official-schema-validation.md
+++ b/lc-gml/official-schema-validation.md
@@ -11,7 +11,7 @@
 * Validate each document against the latest INSPIRE official schema(s), using strict XML schema validation. 
   The official schemas for this data theme are:
   *  Land Cover Raster: https://inspire.ec.europa.eu/schemas/lcr/4.0/LandCoverRaster.xsd
-  *  Land Cover Vector: https://inspire.ec.europa.eu/schemas/lcv/4.0/LandCoverVector.xsd
+  *  Land Cover Vector: https://inspire.ec.europa.eu/schemas/lcv/5.0/LandCoverVector.xsd
 
 **Reference(s)**: 
 


### PR DESCRIPTION
The version of the official schema(s) was updated according to the latest application schema release (https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2024.1).
See the related validator issue for reference: https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1027